### PR TITLE
Spillover based sum animal infections in municipality

### DIFF
--- a/Corona.nlogo
+++ b/Corona.nlogo
@@ -206,6 +206,8 @@ to go
 
   if ticks = 0 or (ticks - Day-COVID-19-Outbreak) mod Frequency = 0 [run Scenario]
 
+  ; For each day we reset the number of totalinfected animals for municipalities to 0
+  ask municipalities [set totalinfectedanimals 0]
   load-animal-farm-infections
 
   ; Write to output file every day

--- a/Corona.nlogo
+++ b/Corona.nlogo
@@ -206,6 +206,11 @@ to go
 
   if ticks = 0 or (ticks - Day-COVID-19-Outbreak) mod Frequency = 0 [run Scenario]
 
+  load-animal-farm-infections
+  ; Introducing animal-human spillover infection in every gemeente
+  ; if conditions are met
+  create-spillover-infc-animal-human-gm
+
   ; Write to output file every day
   file-open (word "data/output/OutputBasemodel.csv")
 
@@ -237,8 +242,6 @@ to go
   ]
 
   file-close
-
-  load-animal-farm-infections
 
 ;  set newtotalinfected sum [totalinfected] of municipalities
 ;  set newtotalhospitalized sum [totalhospitalized] of municipalities

--- a/Corona.nlogo
+++ b/Corona.nlogo
@@ -209,7 +209,9 @@ to go
   load-animal-farm-infections
   ; Introducing animal-human spillover infection in every gemeente
   ; if conditions are met
-  create-spillover-infc-animal-human-gm
+  if (ticks mod spillover-interval = 0)[
+    create-spillover-infc-animal-human-gm
+  ]
 
   ; Write to output file every day
   file-open (word "data/output/OutputBasemodel.csv")
@@ -243,6 +245,8 @@ to go
 
   file-close
 
+  ; The totalspilloveranimalhumaninfections need to set to 0
+  ask municipalities [set totalspilloveranimalhumaninfections 0]
 ;  set newtotalinfected sum [totalinfected] of municipalities
 ;  set newtotalhospitalized sum [totalhospitalized] of municipalities
 

--- a/Corona.nlogo
+++ b/Corona.nlogo
@@ -207,11 +207,6 @@ to go
   if ticks = 0 or (ticks - Day-COVID-19-Outbreak) mod Frequency = 0 [run Scenario]
 
   load-animal-farm-infections
-  ; Introducing animal-human spillover infection in every gemeente
-  ; if conditions are met
-  if (ticks mod spillover-interval = 0)[
-    create-spillover-infc-animal-human-gm
-  ]
 
   ; Write to output file every day
   file-open (word "data/output/OutputBasemodel.csv")
@@ -231,6 +226,11 @@ to go
     if (Scenario ="Original_Pertussis_Model") [decide_commuting_original]
 
     introduce-source-infection-single-municipality
+    ; Introducing animal-human spillover infection in every gemeente
+    ; if conditions are met
+    if (ticks mod spillover-interval = 0)[
+      create-spillover-infc-animal-human-gm
+    ]
 
     recolor-single-municipality
 

--- a/utils/Spillover.nls
+++ b/utils/Spillover.nls
@@ -98,11 +98,9 @@ to load-animal-farm-infections
     ; Assign IV values to turtles
     ask animalfarms [
       set-animal-farm-color
-      
-      if (ticks mod spillover-interval = 0) [
-        set spillover_gm_name gm_name
-        update-num-animal-infc-gm
-      ]
+
+      set spillover_gm_name gm_name
+      update-num-animal-infc-gm
     ]
   ]  
   file-close

--- a/utils/Spillover.nls
+++ b/utils/Spillover.nls
@@ -101,7 +101,6 @@ to load-animal-farm-infections
       
       if (ticks mod spillover-interval = 0) [
         set spillover_gm_name gm_name
-
         update-num-animal-infc-gm
       ]
     ]
@@ -147,7 +146,7 @@ to create-spillover-infc-animal-human-gm
       set new-hum-spillover-infc 1
 
       ; Increasing the number of total spillover infections by 1
-      set totalspilloveranimalhumaninfections totalspilloveranimalhumaninfections + new-hum-spillover-infc
+      set totalspilloveranimalhumaninfections new-hum-spillover-infc
 
       ; Introducing spillover infection based on the spillover-group
       if (spillover-group = "farmers") [

--- a/utils/Spillover.nls
+++ b/utils/Spillover.nls
@@ -137,10 +137,9 @@ to update-num-animal-infc-gm
   ]
 end
 
-; Procedure to introduce spillover infection from one animal-farm to a specific gm
-to create-spillover-infc-animal-human-gm
-  ask municipalities [
-    
+; Municipality procedure to introduce spillover infection based on total
+; num of infected animals
+to create-spillover-infc-animal-human-gm 
     ; Introducing one new human infection whenever iv > spillover-threshold
     (ifelse totalinfectedanimals > spillover-threshold [
       set new-hum-spillover-infc 1
@@ -159,7 +158,6 @@ to create-spillover-infc-animal-human-gm
     [
       set totalspilloveranimalhumaninfections 0
     ])
-  ]
 end
 
 ; Creating separate functions for spillover

--- a/utils/Spillover.nls
+++ b/utils/Spillover.nls
@@ -69,7 +69,6 @@ end
 ; Updates the color of the animal farms and also introduces spillover infections
 to load-animal-farm-infections
   
-  ;
   if ticks = total-timesteps [
     print(word "Day " ticks ": Last day for which we have Boris' animal farm data")
   ]
@@ -104,7 +103,6 @@ to load-animal-farm-infections
         set spillover_gm_name gm_name
 
         update-num-animal-infc-gm
-        create-spillover-infc-animal-human-gm
       ]
     ]
   ]  
@@ -142,14 +140,14 @@ end
 
 ; Procedure to introduce spillover infection from one animal-farm to a specific gm
 to create-spillover-infc-animal-human-gm
-  ask municipalities with [name = spillover_gm_name] [
+  ask municipalities [
     
     ; Introducing one new human infection whenever iv > spillover-threshold
-    (ifelse iv > spillover-threshold [
+    (ifelse totalinfectedanimals > spillover-threshold [
       set new-hum-spillover-infc 1
 
       ; Increasing the number of total spillover infections by 1
-      set totalspilloveranimalhumaninfections totalspilloveranimalhumaninfections + 1
+      set totalspilloveranimalhumaninfections totalspilloveranimalhumaninfections + new-hum-spillover-infc
 
       ; Introducing spillover infection based on the spillover-group
       if (spillover-group = "farmers") [


### PR DESCRIPTION
Solves https://github.com/angelina-momin/IMBIT-model/issues/20

- Bumped version to `1.5`
- We iterate through each animal farm and add the number of animal infections to the corresponding municipality's total animal infections. Spillover infections are then introduced if total no. of animal infections in the municipality > spillover threshold
- Fixed bug- total number of animal infections was previously not resetted to 0 each day. 